### PR TITLE
refactor(Cliente): move required validation to valueObject instances

### DIFF
--- a/src/core/domain/entities/cliente.ts
+++ b/src/core/domain/entities/cliente.ts
@@ -27,13 +27,5 @@ export class Cliente implements Entity {
 
     public validateEntity(): void {
         AssertionConcern.assertArgumentNotEmpty(this.nome, "Nome is required");
-        AssertionConcern.assertArgumentNotEmpty(
-            this.email?.value,
-            "Email is required",
-        );
-        AssertionConcern.assertArgumentNotEmpty(
-            this.cpf?.value,
-            "Cpf is required",
-        );
     }
 }

--- a/src/core/domain/valueObjects/cpf.ts
+++ b/src/core/domain/valueObjects/cpf.ts
@@ -15,6 +15,7 @@ export class Cpf extends ValueObject<CpfProperties> {
     }
 
     public static create(value: string): Cpf {
+        AssertionConcern.assertArgumentNotEmpty(value, "Cpf is required");
         AssertionConcern.assertArgumentIsValidCpf(
             value,
             "Incorrect cpf format",

--- a/src/core/domain/valueObjects/email.ts
+++ b/src/core/domain/valueObjects/email.ts
@@ -15,6 +15,7 @@ export class Email extends ValueObject<EmailProperties> {
     }
 
     public static create(value: string): Email {
+        AssertionConcern.assertArgumentNotEmpty(value, "Email is required");
         AssertionConcern.assertArgumentIsValidEmail(
             value,
             "Incorrect email format",


### PR DESCRIPTION
### Changelog:
- move a validação de campo obrigátorio para as instancias de `valueObject`