### PR TITLE
fix: Removing volumes from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
     db:
-        container_name: fastFood-mongodb
+        container_name: fastFoodMongodb
         image: mongo:latest
         ports:
             - "27017:27017"
@@ -11,12 +11,9 @@ services:
         networks:
             - fastFoodNetwork
     api:
-        container_name: fastFood-api
+        container_name: fastFoodApi
         build: "."
         working_dir: /fastFood
-        volumes:
-            - ./:/fastFood
-            - ./node_modules:/fastFood/node_modules
         environment:
             NODE_ENV: development
             MONGODB_CONN_STRING: mongodb://db:27017
@@ -30,7 +27,7 @@ services:
         networks:
             - fastFoodNetwork
     db-import:
-        container_name: fastFood-data-import
+        container_name: fastFoodImport
         image: mongo:latest
         depends_on:
             - db


### PR DESCRIPTION
O problema que estava dando era o volumes do docker-compose, que usava os arquivos do host e não do container. Então, numa máquina zerada (como é a dos profs) não iriam ter os arquivos de /build e os pacotes