### PR TITLE
Feat/pedido checkout status

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "test": "jest --verbose false",
         "dev": "ts-node-dev -r tsconfig-paths/register --inspect --transpile-only --ignore-watch node_modules src/api/index.ts ",
         "build": "tsc --project ./tsconfig.build.json && tsc-alias -p ./tsconfig.build.json",
-        "start": "node build/adapter/driver/api/index.js",
+        "start": "node build/api/index.js",
         "start:docker": "docker compose -p fastfood up --build",
         "lint": "eslint .",
         "lint:fix": "eslint --fix --ext .ts .",

--- a/src/adapters/mappers/pedidoMapper.ts
+++ b/src/adapters/mappers/pedidoMapper.ts
@@ -10,6 +10,7 @@ export class PedidoMapper {
         return new Pedido({
             id: dto.id,
             status: dto.status,
+            pagamento: dto.pagamento,
             valorTotal: dto.valorTotal,
             observacoes: dto.observacoes,
             itens: dto.itens,
@@ -30,6 +31,7 @@ export class PedidoMapper {
         return {
             id: pedido.id,
             status: pedido.status,
+            pagamento: pedido.pagamento,
             valorTotal: pedido.valorTotal,
             itens: pedido.itens,
             observacoes: pedido.observacoes,

--- a/src/api/docs/paths/pedido.ts
+++ b/src/api/docs/paths/pedido.ts
@@ -1,8 +1,17 @@
+import { StatusPagamentoEnum, StatusPedidoEnum } from "entities/pedido";
 import { serverError, unprocessableEntity } from "../defaults";
+
+const StatusEnum = Object.values(StatusPedidoEnum);
+const PagamentoEnum = Object.values(StatusPagamentoEnum);
 
 const PedidoFields = {
     status: {
         type: "string",
+        enum: StatusEnum,
+    },
+    pagamento: {
+        type: "string",
+        enum: PagamentoEnum,
     },
     valorTotal: {
         type: "number",
@@ -60,7 +69,7 @@ export const PedidoPaths = {
         },
         post: {
             tags: ["pedido"],
-            summary: "Rota para cadastrar um pedido",
+            summary: "Rota para fazer o checkout (criar) de um pedido",
             requestBody: {
                 required: true,
                 content: {
@@ -93,16 +102,10 @@ export const PedidoPaths = {
                 201: {
                     description: "Pedido cadastrado",
                     content: {
-                        "application/json": {
+                        "text/plain": {
                             schema: {
-                                type: "object",
-                                properties: {
-                                    id: {
-                                        type: "string",
-                                    },
-                                    ...PedidoFields,
-                                },
-                                required: RequiredFields,
+                                type: "string",
+                                example: "64deb912c3d31615c0af2863 (id)",
                             },
                         },
                     },
@@ -179,6 +182,65 @@ export const PedidoPaths = {
             responses: {
                 201: {
                     description: "Pedido atualizado",
+                    content: {
+                        "application/json": {
+                            schema: {
+                                type: "object",
+                                properties: {
+                                    id: {
+                                        type: "string",
+                                    },
+                                    ...PedidoFields,
+                                },
+                                required: RequiredFields,
+                            },
+                        },
+                    },
+                },
+                422: {
+                    ...unprocessableEntity,
+                },
+                500: {
+                    ...serverError,
+                },
+            },
+        },
+    },
+    "/pedido/{id}/update-status": {
+        patch: {
+            tags: ["pedido"],
+            summary: "Rota para atualizar o status de um pedido",
+            parameters: [
+                {
+                    in: "path",
+                    name: "id",
+                    description: "id do pedido a ser atualizado",
+                    required: true,
+                    schema: {
+                        type: "string",
+                    },
+                },
+            ],
+            requestBody: {
+                required: true,
+                content: {
+                    "application/json": {
+                        schema: {
+                            type: "object",
+                            enum: StatusEnum,
+                            properties: {
+                                status: {
+                                    type: "string",
+                                }
+                            },
+                            required: "status",
+                        },
+                    },
+                },
+            },
+            responses: {
+                201: {
+                    description: "Status do pedido atualizado",
                     content: {
                         "application/json": {
                             schema: {

--- a/src/api/middlewares/errorHandler.ts
+++ b/src/api/middlewares/errorHandler.ts
@@ -4,6 +4,7 @@ import { NextFunction, Request, Response } from "express";
 import { StatusCode } from "utils/statusCode";
 import { ResourceNotFoundError } from "utils/errors/resourceNotFoundError";
 import { ValidationError } from "utils/errors/validationError";
+import { BadError } from "utils/errors/badError";
 
 // ? "_next" parameter is not used but is needed for "express-async-errors" package
 // ? Since whe are returning the response there is no use for it
@@ -27,6 +28,14 @@ export function errorHandler(
     if (error instanceof ResourceNotFoundError) {
         return res.status(StatusCode.notFound).json({
             code: StatusCode.notFound,
+            name: error?.name,
+            message: error?.message,
+        });
+    }
+
+    if (error instanceof BadError) {
+        return res.status(StatusCode.badRequest).json({
+            code: StatusCode.badRequest,
             name: error?.name,
             message: error?.message,
         });

--- a/src/api/routes/pedidoRouter.ts
+++ b/src/api/routes/pedidoRouter.ts
@@ -20,6 +20,10 @@ export function makePedidoRouter(): Router {
         pedidoController.patch(req, res, next);
     });
 
+    pedidoRouter.patch("/:id/update-status", async (req, res, next) => {
+        pedidoController.patchStatus(req, res, next);
+    });
+
     pedidoRouter.patch("/:id/payment-checkout", async (req, res, next) => {
         pedidoController.patchPaymentStatus(req, res, next);
     });

--- a/src/controllers/pedido/controller.ts
+++ b/src/controllers/pedido/controller.ts
@@ -37,8 +37,8 @@ export class PedidoController {
         next: NextFunction,
     ): Promise<Response> {
         try {
-            const result = await this.pedidoUseCase.create(req.body);
-            return res.status(StatusCode.created).json(result);
+            const result = await this.pedidoUseCase.checkout(req.body);
+            return res.status(StatusCode.created).json(result.id);
         } catch (error) {
             next(error);
         }
@@ -53,6 +53,21 @@ export class PedidoController {
 
         try {
             const result = await this.pedidoUseCase.update(id, req.body);
+            return res.status(StatusCode.ok).json(result);
+        } catch (error) {
+            next(error);
+        }
+    }
+
+    public async patchStatus(
+        req: Request,
+        res: Response,
+        next: NextFunction,
+    ): Promise<Response> {
+        const { id } = req.params;
+
+        try {
+            const result = await this.pedidoUseCase.updateStatus(id, req.body?.status ?? undefined);
             return res.status(StatusCode.ok).json(result);
         } catch (error) {
             next(error);

--- a/src/entities/pedido.ts
+++ b/src/entities/pedido.ts
@@ -3,14 +3,20 @@ import { AssertionConcern } from "utils/assertionConcern";
 import { Cliente } from "./cliente";
 
 export enum StatusPedidoEnum {
-    Pagamento_pendente = "pagamento_pendente",
     Recebido = "recebido",
     Em_preparacao = "em_preparacao",
     Pronto = "pronto",
     Finalizado = "finalizado",
 }
 
+export enum StatusPagamentoEnum {
+    Pagamento_pendente = "pagamento_pendente",
+    Pagamento_aprovado = "pagamento_aprovado",
+    Pagamento_nao_autorizado = "pagamento_nao_autorizado"
+}
+
 export type StatusPedido = `${StatusPedidoEnum}`;
+export type StatusPagamento = `${StatusPagamentoEnum}`;
 
 export interface Item {
     produtoId: string;
@@ -21,6 +27,7 @@ export interface Item {
 export class Pedido implements Entity {
     id: string;
     status: StatusPedido;
+    pagamento: StatusPagamento;
     valorTotal: number;
     cliente?: Cliente;
     itens: Item[];
@@ -29,6 +36,7 @@ export class Pedido implements Entity {
     constructor({
         id,
         status,
+        pagamento,
         valorTotal,
         cliente,
         itens,
@@ -36,6 +44,7 @@ export class Pedido implements Entity {
     }: {
         id?: string;
         status?: StatusPedido;
+        pagamento?: StatusPagamento;
         valorTotal: number;
         cliente?: Cliente;
         itens: Item[];
@@ -43,6 +52,7 @@ export class Pedido implements Entity {
     }) {
         this.id = id;
         this.status = status || StatusPedidoEnum.Recebido;
+        this.pagamento = pagamento || StatusPagamentoEnum.Pagamento_pendente;
         this.valorTotal = valorTotal;
         this.cliente = cliente || null;
         this.itens = itens;
@@ -66,6 +76,12 @@ export class Pedido implements Entity {
             this.status,
             Object.values(StatusPedidoEnum),
             `Status must be one of ${Object.values(StatusPedidoEnum)}`,
+        );
+
+        AssertionConcern.assertArgumentIsValid(
+            this.pagamento,
+            Object.values(StatusPagamentoEnum),
+            `Status must be one of ${Object.values(StatusPagamentoEnum)}`,
         );
 
         AssertionConcern.assertArgumentNotEmpty(

--- a/src/external/mongo/models/Pedido.ts
+++ b/src/external/mongo/models/Pedido.ts
@@ -1,4 +1,4 @@
-import { Item, StatusPedidoEnum } from "entities/pedido";
+import { Item, StatusPagamentoEnum, StatusPedidoEnum } from "entities/pedido";
 import mongoose from "mongoose";
 
 const ItemSchema = new mongoose.Schema<Item>({
@@ -15,7 +15,13 @@ const PedidoSchema = new mongoose.Schema(
         status: {
             type: String,
             enum: Object.values(StatusPedidoEnum),
-            default: StatusPedidoEnum.Pagamento_pendente,
+            default: StatusPedidoEnum.Recebido,
+            required: true,
+        },
+        pagamento: {
+            type: String,
+            enum: Object.values(StatusPagamentoEnum),
+            default: StatusPagamentoEnum.Pagamento_pendente,
             required: true,
         },
         valorTotal: {

--- a/src/gateways/pedidoGateway.ts
+++ b/src/gateways/pedidoGateway.ts
@@ -1,7 +1,7 @@
 import { PedidoDTO, ClienteDTO } from "useCases";
 import { PedidoGateway } from "interfaces/gateways/pedidoGateway.interface";
 
-import { Pedido } from "entities/pedido";
+import { Pedido, StatusPedidoEnum } from "entities/pedido";
 import { PedidoModel } from "external/mongo/models";
 import { PedidoMapper } from "adapters/mappers";
 
@@ -36,6 +36,7 @@ export class PedidoMongoGateway implements PedidoGateway {
                 {
                     id: result._id,
                     status: result.status,
+                    pagamento: result.pagamento,
                     valorTotal: result.valorTotal,
                     itens: result.itens,
                     observacoes: result.observacoes,
@@ -102,6 +103,7 @@ export class PedidoMongoGateway implements PedidoGateway {
                 {
                     id: result._id,
                     status: result.status,
+                    pagamento: result.pagamento,
                     valorTotal: result.valorTotal,
                     itens: result.itens,
                     observacoes: result.observacoes,
@@ -128,6 +130,7 @@ export class PedidoMongoGateway implements PedidoGateway {
             {
                 id: result.id,
                 status: result.status,
+                pagamento: result.pagamento,
                 valorTotal: result.valorTotal,
                 itens: result.itens,
                 observacoes: result.observacoes,
@@ -141,7 +144,7 @@ export class PedidoMongoGateway implements PedidoGateway {
         );
     }
 
-    async create(pedido: PedidoDTO): Promise<Pedido> {
+    async checkout(pedido: PedidoDTO): Promise<Pedido> {
         const result = await this.pedidoModel.create({
             valorTotal: pedido.valorTotal,
             itens: pedido.itens,
@@ -152,6 +155,7 @@ export class PedidoMongoGateway implements PedidoGateway {
         return PedidoMapper.toDomain({
             id: result.id,
             status: result.status,
+            pagamento: result.pagamento,
             valorTotal: result.valorTotal,
             itens: result.itens,
             observacoes: result.observacoes,
@@ -172,6 +176,35 @@ export class PedidoMongoGateway implements PedidoGateway {
             {
                 id: result.id,
                 status: result.status,
+                pagamento: result.pagamento,
+                valorTotal: result.valorTotal,
+                itens: result.itens,
+                observacoes: result.observacoes,
+            },
+            {
+                id: result?.cliente?.id,
+                nome: result?.cliente?.nome,
+                email: result?.cliente?.email,
+                cpf: result?.cliente?.cpf,
+            },
+        );
+    }
+
+    async updateStatus(
+        id: string,
+        status: StatusPedidoEnum,
+    ): Promise<Pedido> {
+        const result = await this.pedidoModel
+            .findOneAndUpdate({ _id: id }, { status }, {
+                new: true,
+            })
+            .populate<{ cliente: ClienteDTO }>("cliente");
+
+        return PedidoMapper.toDomain(
+            {
+                id: result.id,
+                status: result.status,
+                pagamento: result.pagamento,
                 valorTotal: result.valorTotal,
                 itens: result.itens,
                 observacoes: result.observacoes,

--- a/src/gateways/pedidoGateway.ts
+++ b/src/gateways/pedidoGateway.ts
@@ -126,22 +126,25 @@ export class PedidoMongoGateway implements PedidoGateway {
             })
             .populate<{ cliente: ClienteDTO }>("cliente");
 
-        return PedidoMapper.toDomain(
-            {
-                id: result.id,
-                status: result.status,
-                pagamento: result.pagamento,
-                valorTotal: result.valorTotal,
-                itens: result.itens,
-                observacoes: result.observacoes,
-            },
-            {
-                id: result?.cliente?.id,
-                nome: result?.cliente?.nome,
-                email: result?.cliente?.email,
-                cpf: result?.cliente?.cpf,
-            },
-        );
+        if (result) {
+            return PedidoMapper.toDomain(
+                {
+                    id: result.id,
+                    status: result.status,
+                    pagamento: result.pagamento,
+                    valorTotal: result.valorTotal,
+                    itens: result.itens,
+                    observacoes: result.observacoes,
+                },
+                {
+                    id: result?.cliente?.id,
+                    nome: result?.cliente?.nome,
+                    email: result?.cliente?.email,
+                    cpf: result?.cliente?.cpf,
+                },
+            );
+        }
+
     }
 
     async checkout(pedido: PedidoDTO): Promise<Pedido> {

--- a/src/interfaces/gateways/pedidoGateway.interface.ts
+++ b/src/interfaces/gateways/pedidoGateway.interface.ts
@@ -1,13 +1,17 @@
-import { Pedido } from "entities/pedido";
+import { Pedido, StatusPedidoEnum } from "entities/pedido";
 import { PedidoDTO } from "useCases";
 
 export interface PedidoGateway {
     getAll(filters?: Partial<Pedido>): Promise<Pedido[]>;
     getAllOrderedByStatus(filters?: Partial<Pedido>): Promise<Pedido[]>;
     getById(id: string): Promise<Pedido>;
-    create(pedido: PedidoDTO): Promise<Pedido>;
+    checkout(pedido: PedidoDTO): Promise<Pedido>;
     update(
         id: string,
         pedido: Omit<Partial<Pedido>, "id" | "cliente">,
+    ): Promise<Pedido>;
+    updateStatus(
+        id: string,
+        status: StatusPedidoEnum,
     ): Promise<Pedido>;
 }

--- a/src/useCases/pedido/dto.ts
+++ b/src/useCases/pedido/dto.ts
@@ -1,8 +1,9 @@
-import { StatusPedido, Item } from "entities/pedido";
+import { StatusPedido, Item, StatusPagamento } from "entities/pedido";
 
 export interface PedidoDTO {
     id?: string;
     status?: StatusPedido;
+    pagamento?: StatusPagamento;
     valorTotal?: number;
     observacoes?: string;
     itens: Item[];

--- a/src/useCases/pedido/pedido.interface.ts
+++ b/src/useCases/pedido/pedido.interface.ts
@@ -1,12 +1,17 @@
+import { StatusPedidoEnum } from "entities/pedido";
 import { PedidoDTO } from "./dto";
 
 export interface IPedidoUseCase {
     getAll(): Promise<PedidoDTO[]>;
     getAllOrderedByStatus(): Promise<PedidoDTO[]>;
     getById(id: string): Promise<PedidoDTO>;
-    create(pedido: PedidoDTO): Promise<PedidoDTO>;
+    checkout(pedido: PedidoDTO): Promise<PedidoDTO>;
     update(
         id: string,
         pedido: Omit<Partial<PedidoDTO>, "id" | "cliente">,
+    ): Promise<PedidoDTO>;
+    updateStatus(
+        id: string,
+        status: StatusPedidoEnum,
     ): Promise<PedidoDTO>;
 }

--- a/src/useCases/pedido/pedidoUseCase.ts
+++ b/src/useCases/pedido/pedidoUseCase.ts
@@ -77,6 +77,14 @@ export class PedidoUseCase implements IPedidoUseCase {
     ): Promise<PedidoDTO> {
         AssertionConcern.assertArgumentNotEmpty(pedido, "Pedido is required");
 
+        if (pedido.status) {
+            throw new Error("Não é possível alterar o status por essa rota");
+        }
+
+        if (pedido.pagamento) {
+            throw new Error("Não é possível alterar o status de pagamento por essa rota");
+        }
+
         const doesPedidoExists = await this.pedidoGateway.getById(id);
 
         if (!doesPedidoExists) {

--- a/src/useCases/pedido/pedidoUseCase.ts
+++ b/src/useCases/pedido/pedidoUseCase.ts
@@ -105,9 +105,6 @@ export class PedidoUseCase implements IPedidoUseCase {
 
         const currentStatus = statusOrder.indexOf(pedidoToUpdateStatus.status as StatusPedidoEnum);
 
-        console.log(currentStatus);
-        console.log(expectedStatus);
-
         if (
             expectedStatus - 1 !== currentStatus
         ) {

--- a/src/utils/errors/badError.ts
+++ b/src/utils/errors/badError.ts
@@ -1,0 +1,6 @@
+export class BadError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "BadError";
+    }
+}

--- a/tests/useCases/pedido/index.test.ts
+++ b/tests/useCases/pedido/index.test.ts
@@ -1,5 +1,5 @@
 import { Cliente } from "entities/cliente";
-import { StatusPedidoEnum, Pedido } from "entities/pedido";
+import { StatusPedidoEnum, Pedido, StatusPagamentoEnum } from "entities/pedido";
 import { Produto, CategoriaEnum } from "entities/produto";
 import { PedidoGateway } from "interfaces/gateways/pedidoGateway.interface";
 import { ProdutoGateway } from "interfaces/gateways/produtoGateway.interface";
@@ -42,7 +42,8 @@ const mockPedidoDTO1 = {
     id: "any_id",
     valorTotal: 10,
     cliente: mockClienteDTO,
-    status: StatusPedidoEnum.Pagamento_pendente,
+    status: StatusPedidoEnum.Recebido,
+    pagamento: StatusPagamentoEnum.Pagamento_pendente,
     itens: [
         {
             produtoId: LANCHE.id,
@@ -55,6 +56,7 @@ const mockPedidoDTO2 = {
     id: "any_another_id",
     valorTotal: 29.9,
     status: StatusPedidoEnum.Em_preparacao,
+    pagamento: StatusPagamentoEnum.Pagamento_aprovado,
     itens: [
         {
             produtoId: LANCHE.id,
@@ -67,9 +69,10 @@ const mockPedidoDTO2 = {
     ],
 };
 const mockPedidoDTO3 = {
-    id: "any_another_id",
+    id: "any_another_created_id",
     valorTotal: 29.9,
     status: StatusPedidoEnum.Recebido,
+    pagamento: StatusPagamentoEnum.Pagamento_pendente,
     itens: [
         {
             produtoId: LANCHE.id,
@@ -93,19 +96,21 @@ describe("Given PedidoUseCases", () => {
             valorTotal: mockPedidoDTO1.valorTotal,
             cliente: mockCliente,
             status: mockPedidoDTO1.status,
+            pagamento: mockPedidoDTO1.pagamento,
             itens: mockPedidoDTO1.itens,
         }),
         new Pedido({
             id: mockPedidoDTO2.id,
             valorTotal: mockPedidoDTO2.valorTotal,
             status: mockPedidoDTO2.status,
+            pagamento: mockPedidoDTO2.pagamento,
             itens: mockPedidoDTO2.itens,
         }),
     ];
 
     class PedidoGatewayStub implements PedidoGateway {
         getById(id: string): Promise<Pedido> {
-            return new Promise((resolve) => resolve(mockPedidos[0]));
+            return new Promise((resolve) => resolve(mockPedidos.find(p => p.id === id)));
         }
         getAllOrderedByStatus(): Promise<Pedido[]> {
             return new Promise((resolve) => resolve(mockPedidos));
@@ -113,10 +118,13 @@ describe("Given PedidoUseCases", () => {
         getAll(): Promise<Pedido[]> {
             return new Promise((resolve) => resolve(mockPedidos));
         }
-        create(pedido: Pedido): Promise<Pedido> {
+        checkout(pedido: Pedido): Promise<Pedido> {
             return new Promise((resolve) => resolve(mockPedidos[1]));
         }
         update(id: string, pedido: Partial<Pedido>): Promise<Pedido> {
+            return new Promise((resolve) => resolve(mockPedidos[1]));
+        }
+        updateStatus(id: string, status: StatusPedidoEnum): Promise<Pedido> {
             return new Promise((resolve) => resolve(mockPedidos[1]));
         }
     }
@@ -163,11 +171,11 @@ describe("Given PedidoUseCases", () => {
         });
     });
 
-    describe("When create is called", () => {
-        it("should call create on the gateway and return the created pedido", async () => {
-            const create = jest.spyOn(gatewayStub, "create");
+    describe("When checkout is called", () => {
+        it("should call checkout on the gateway and return the created pedido id", async () => {
+            const create = jest.spyOn(gatewayStub, "checkout");
 
-            const pedido = await sut.create({
+            const pedido = await sut.checkout({
                 // valorTotal: 29.9,
                 itens: [
                     {
@@ -188,10 +196,10 @@ describe("Given PedidoUseCases", () => {
     describe("When update is called", () => {
         it("should call update on the gateway and return the updated pedido", async () => {
             const updateSpy = jest.spyOn(gatewayStub, "update");
-            const pedido = await sut.update("any-another-id", {
+            const pedido = await sut.update("any_another_id", {
                 status: StatusPedidoEnum.Em_preparacao,
             });
-            expect(updateSpy).toHaveBeenCalledWith("any-another-id", {
+            expect(updateSpy).toHaveBeenCalledWith("any_another_id", {
                 status: StatusPedidoEnum.Em_preparacao,
             });
             expect(pedido).toEqual(mockPedidoDTO2);
@@ -212,16 +220,13 @@ describe("Given PedidoUseCases", () => {
             expect(getByIdSpy).toHaveBeenCalledWith("nonexistent-id");
         });
     });
-    describe("When updatePaymentStatus is called", () => {
-        it("should call update on the gateway and return the pedido with the updated status to Recebido", async () => {
-            const updateSpy = jest
-                .spyOn(gatewayStub, "update")
-                .mockResolvedValueOnce(new Pedido(mockPedidoDTO3));
-            const pedido = await sut.updatePaymentStatus("any-another-id");
-            expect(updateSpy).toHaveBeenCalledWith("any-another-id", {
-                status: StatusPedidoEnum.Recebido,
-            });
-            expect(pedido).toEqual(mockPedidoDTO3);
+
+    describe("When updateStatus is called", () => {
+        it("should call updateStatus on the gateway and return the updated pedido", async () => {
+            const updateStatusSpy = jest.spyOn(gatewayStub, "updateStatus");
+            const pedido = await sut.updateStatus("any_another_id", StatusPedidoEnum.Pronto);
+            expect(updateStatusSpy).toHaveBeenCalledWith("any_another_id", StatusPedidoEnum.Pronto);
+            expect(pedido).toEqual(mockPedidoDTO2);
         });
 
         it("should throw an error if the pedido does not exist", async () => {
@@ -229,7 +234,7 @@ describe("Given PedidoUseCases", () => {
                 .spyOn(gatewayStub, "getById")
                 .mockResolvedValueOnce(null);
 
-            const pedido = sut.updatePaymentStatus("nonexistent-id");
+            const pedido = sut.updateStatus("nonexistent-id", StatusPedidoEnum.Em_preparacao);
 
             await expect(pedido).rejects.toThrowError(
                 new Error("Pedido não encontrado"),
@@ -237,17 +242,83 @@ describe("Given PedidoUseCases", () => {
             expect(getByIdSpy).toHaveBeenCalledWith("nonexistent-id");
         });
 
-        it("should throw an error if the pedido is already paid", async () => {
-            const getByIdSpy = jest
-                .spyOn(gatewayStub, "getById")
-                .mockResolvedValueOnce(new Pedido(mockPedidoDTO2));
-
-            const pedido = sut.updatePaymentStatus("already-paid-id");
+        it("should throw an error if the request body does not contain status", async () => {
+            const pedido = sut.updateStatus("any_another_id", undefined);
 
             await expect(pedido).rejects.toThrowError(
-                new Error("Pedido já foi pago"),
+                new Error("É necessário informar o status"),
             );
-            expect(getByIdSpy).toHaveBeenCalledWith("already-paid-id");
+        });
+    
+        it("should throw an error if the request body does not contain a valid status", async () => {
+            const pedido = sut.updateStatus("any_another_id", "invalid_status" as any);
+
+            await expect(pedido).rejects.toThrowError(
+                new Error("É necessário informar o status"),
+            );
+        });
+
+        it("should throw an error if the order's payment is not authorized yet", async () => {
+            const pedido = sut.updateStatus("any_id", StatusPedidoEnum.Em_preparacao);
+
+            await expect(pedido).rejects.toThrowError(
+                new Error("Não é possível alterar o status pois o pagamento ainda não foi aprovado!"),
+            );
+        });
+
+        it("should throw an error if the status is before current status", async () => {
+            const pedido = sut.updateStatus("any_another_id", StatusPedidoEnum.Recebido);
+
+            await expect(pedido).rejects.toThrowError(
+                new Error("Status inválido, o próximo status válido para esse pedido é: pronto"),
+            );
+        });
+
+        it("should throw an error if the status is after expected status", async () => {
+            const pedido = sut.updateStatus("any_another_id", StatusPedidoEnum.Finalizado);
+
+            await expect(pedido).rejects.toThrowError(
+                new Error("Status inválido, o próximo status válido para esse pedido é: pronto"),
+            );
         });
     });
+    // describe("When updatePaymentStatus is called", () => {
+    //     it("should call update on the gateway and return the pedido with the updated status to Recebido", async () => {
+    //         const updateSpy = jest
+    //             .spyOn(gatewayStub, "update")
+    //             .mockResolvedValueOnce(new Pedido(mockPedidoDTO3));
+    //         const pedido = await sut.updatePaymentStatus("any_another_created_id");
+    //         expect(updateSpy).toHaveBeenCalledWith("any_another_created_id", {
+    //             pagamento: StatusPagamentoEnum.Pagamento_aprovado,
+    //             status: StatusPedidoEnum.Recebido,
+    //         });
+    //         expect(pedido).toEqual(mockPedidoDTO3);
+    //     });
+
+    //     it("should throw an error if the pedido does not exist", async () => {
+    //         const getByIdSpy = jest
+    //             .spyOn(gatewayStub, "getById")
+    //             .mockResolvedValueOnce(null);
+
+    //         const pedido = sut.updatePaymentStatus("nonexistent-id");
+
+    //         await expect(pedido).rejects.toThrowError(
+    //             new Error("Pedido não encontrado"),
+    //         );
+    //         expect(getByIdSpy).toHaveBeenCalledWith("nonexistent-id");
+    //     });
+
+    //     it("should throw an error if the pedido is already paid", async () => {
+    //         const getByIdSpy = jest
+    //             .spyOn(gatewayStub, "getById")
+    //             .mockResolvedValueOnce(new Pedido(mockPedidoDTO2));
+
+    //         const pedido = sut.updatePaymentStatus("already-paid-id");
+
+    //         await expect(pedido).rejects.toThrowError(
+    //             new Error("Pedido já foi pago"),
+    //         );
+    //         expect(getByIdSpy).toHaveBeenCalledWith("already-paid-id");
+    //     });
+    // });
 });

--- a/tests/useCases/pedido/index.test.ts
+++ b/tests/useCases/pedido/index.test.ts
@@ -197,10 +197,10 @@ describe("Given PedidoUseCases", () => {
         it("should call update on the gateway and return the updated pedido", async () => {
             const updateSpy = jest.spyOn(gatewayStub, "update");
             const pedido = await sut.update("any_another_id", {
-                status: StatusPedidoEnum.Em_preparacao,
+                valorTotal: 10,
             });
             expect(updateSpy).toHaveBeenCalledWith("any_another_id", {
-                status: StatusPedidoEnum.Em_preparacao,
+                valorTotal: 10,
             });
             expect(pedido).toEqual(mockPedidoDTO2);
         });
@@ -211,13 +211,33 @@ describe("Given PedidoUseCases", () => {
                 .mockResolvedValueOnce(null);
 
             const pedido = sut.update("nonexistent-id", {
-                status: StatusPedidoEnum.Em_preparacao,
+                valorTotal: 10,
             });
 
             await expect(pedido).rejects.toThrowError(
                 new Error("Pedido não encontrado"),
             );
             expect(getByIdSpy).toHaveBeenCalledWith("nonexistent-id");
+        });
+
+        it("should throw an error if has attempt to update status", async () => {
+            const pedido = sut.update("any_another_id", {
+                status: StatusPedidoEnum.Em_preparacao,
+            });
+
+            await expect(pedido).rejects.toThrowError(
+                new Error("Não é possível alterar o status por essa rota"),
+            );
+        });
+
+        it("should throw an error if has attempt to update payment status", async () => {
+            const pedido = sut.update("any_another_id", {
+                pagamento: StatusPagamentoEnum.Pagamento_aprovado,
+            });
+
+            await expect(pedido).rejects.toThrowError(
+                new Error("Não é possível alterar o status de pagamento por essa rota"),
+            );
         });
     });
 
@@ -254,7 +274,7 @@ describe("Given PedidoUseCases", () => {
             const pedido = sut.updateStatus("any_another_id", "invalid_status" as any);
 
             await expect(pedido).rejects.toThrowError(
-                new Error("É necessário informar o status"),
+                new Error("É necessário informar um status válido"),
             );
         });
 

--- a/tests/useCases/pedido/index.test.ts
+++ b/tests/useCases/pedido/index.test.ts
@@ -69,10 +69,10 @@ const mockPedidoDTO2 = {
     ],
 };
 const mockPedidoDTO3 = {
-    id: "any_another_created_id",
+    id: "any_onemore_id",
     valorTotal: 29.9,
-    status: StatusPedidoEnum.Recebido,
-    pagamento: StatusPagamentoEnum.Pagamento_pendente,
+    status: StatusPedidoEnum.Finalizado,
+    pagamento: StatusPagamentoEnum.Pagamento_aprovado,
     itens: [
         {
             produtoId: LANCHE.id,
@@ -105,6 +105,13 @@ describe("Given PedidoUseCases", () => {
             status: mockPedidoDTO2.status,
             pagamento: mockPedidoDTO2.pagamento,
             itens: mockPedidoDTO2.itens,
+        }),
+        new Pedido({
+            id: mockPedidoDTO3.id,
+            valorTotal: mockPedidoDTO3.valorTotal,
+            status: mockPedidoDTO3.status,
+            pagamento: mockPedidoDTO3.pagamento,
+            itens: mockPedidoDTO3.itens,
         }),
     ];
 
@@ -154,7 +161,7 @@ describe("Given PedidoUseCases", () => {
 
             const pedidos = await sut.getAll();
             expect(getAll).toHaveBeenCalled();
-            expect(pedidos).toEqual([mockPedidoDTO1, mockPedidoDTO2]);
+            expect(pedidos).toEqual([mockPedidoDTO1, mockPedidoDTO2, mockPedidoDTO3]);
         });
     });
 
@@ -167,7 +174,7 @@ describe("Given PedidoUseCases", () => {
 
             const pedidos = await sut.getAllOrderedByStatus();
             expect(getAllOrderedByStatus).toHaveBeenCalled();
-            expect(pedidos).toEqual([mockPedidoDTO1, mockPedidoDTO2]);
+            expect(pedidos).toEqual([mockPedidoDTO1, mockPedidoDTO2, mockPedidoDTO3]);
         });
     });
 
@@ -267,6 +274,14 @@ describe("Given PedidoUseCases", () => {
 
             await expect(pedido).rejects.toThrowError(
                 new Error("É necessário informar o status"),
+            );
+        });
+
+        it("should throw an error if the order is already 'finalizado'", async () => {
+            const pedido = sut.updateStatus("any_onemore_id", StatusPedidoEnum.Finalizado);
+
+            await expect(pedido).rejects.toThrowError(
+                new Error("Não é possível alterar o status pois o pedido já está finalizado!"),
             );
         });
     


### PR DESCRIPTION
# Observações:

- Mudei os nomes create para checkout
- Alterei o retorno do checkout para ser apenas o id
- No swagger também alterei para apenas text/plain o retorno no checkout
- Criei um campo separado para o pagamento
- Implementei o updateStatus com as regras para não permitir atualizar se o pagamento estiver diferente de autorizado e para não deixar voltar ou pular um status
- Mantive o update mas pensei em tirar das rotas expostas na API

**Testei a rota que os professores alegaram problemas e não deu erro pra mim, se puderem verificar, agradeço**