### PR TITLE
pipeline para rodar os testes e publicar a imagem no docker

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,31 @@
+name: pipeline
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build_and_test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: ☁️ checkout repository
+      uses: actions/checkout@v3
+  
+    - name: Use Node.js 18.x
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18.x
+        cache: 'npm'
+  
+    - name: "🛠 install dependencies"
+      run: npm ci
+  
+    - name: "📦 run build"
+      run: npm run build --if-present
+
+    - name: "🔍 run tests"
+      run: npm test

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -29,3 +29,25 @@ jobs:
 
     - name: "🔍 run tests"
       run: npm test
+
+  publish_image:
+    runs-on: ubuntu-latest
+    needs: build_and_test
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: "🐋 docker login"
+      env:
+        DOCKER_USER: ${{secrets.DOCKER_USER}}
+        DOCKER_ACCESS_TOKEN: ${{secrets.DOCKER_ACCESS_TOKEN}}
+      run: |
+        docker login -u $DOCKER_USER -p $DOCKER_ACCESS_TOKEN
+
+    - name: "🖼️ build docker image"
+      run: docker build . --file Dockerfile --tag ${{secrets.DOCKER_USER}}/app-fast-food:latest
+
+    - name: "🚀 docker push"
+      run: docker push ${{secrets.DOCKER_USER}}/app-fast-food:latest
+        


### PR DESCRIPTION
Criação da pipeline que vai rodar CI/CD da aplicação. Nesse PR, configurei para rodar o npm ci (puxa os pacotes do package-lock.json para garantir que não vai pegar uma versão diferente), npm run build e por fim roda os testes. A ideia é rodar sempre que houver um push na main ou pull request apontando pra ela.

Sobre publicar no docker hub, eu criei um job que faz isso e para isso precisei de 2 secrets, DOCKER_USER e DOCKER_ACCESS_TOKEN. A action só publicará a imagem quando o PR for mergeado na MAIN.

Para testar:

- comentar a linha que condiciona o job a executar somente na main:

```yaml
#if: github.ref == 'refs/heads/main'
```

nas configs de secrets do repositório trocar pro seu usuário do docker, gerar um access token no seu docker hub e trocar na secret do github também.

Vi que o K8S está usando as credenciais do @daniel-eiro, então não podemos esquecer de trocar as secrets do github aqui no repo para as dele quando formos entregar a fase.

